### PR TITLE
MF-40-Instacja-account-powinna-mie-po-zalogowaniu-automatycznie-setowane-id-u-ytkownika

### DIFF
--- a/src/Extension/Account/Account.php
+++ b/src/Extension/Account/Account.php
@@ -78,6 +78,7 @@ class Account
             self::$accountId = (int)Session::get(self::$sessionName);
             self::$account = self::getAccountData(self::$accountId);
             self::$accountRememberField = new AccountRememberField();
+            self::$tableInstance->setId(self::$accountId);
         }
     }
 


### PR DESCRIPTION
Instacja account powinna mieć po zalogowaniu automatycznie setowane id użytkownika