### PR TITLE
MF-35-B-dy-w-API-powinny-zwraca-JSON-a-nie-HTML

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -62,6 +62,12 @@ class Kernel
     private static object $config;
 
     /**
+     * Parametry kontrolera
+     * @var array
+     */
+    public static array $controllerParams;
+
+    /**
      * Init project
      * @param string $projectPath
      * @return void
@@ -223,6 +229,8 @@ class Kernel
      */
     public static function init(?string $controllerName = null, string $controllerMethod = 'index', array $controllerArguments = [], array $params = []): void
     {
+        self::$controllerParams = $params;
+
         if (!self::$projectPath) {
             throw new MicroFrameworkException('Project is not defined', 500);
         }

--- a/src/View.php
+++ b/src/View.php
@@ -5,6 +5,7 @@ namespace Krzysztofzylka\MicroFramework;
 use Exception;
 use Krzysztofzylka\MicroFramework\Exception\ViewException;
 use Krzysztofzylka\MicroFramework\Extension\Account\Account;
+use krzysztofzylka\SimpleLibraries\Library\Response;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
@@ -90,6 +91,22 @@ class View
         }
 
         http_response_code($code);
+
+        if (isset(Kernel::$controllerParams['api']) && Kernel::$controllerParams['api']) {
+            $data = [
+                'error' => [
+                    'message' => $exception->getMessage(),
+                    'code' => $code
+                ]
+            ];
+
+            if (Kernel::getConfig()->debug) {
+                $data['error']['hiddenMessage'] = $hiddenMessage;
+            }
+
+            $response = new Response();
+            $response->json($data);
+        }
 
         return $this->render(
             [


### PR DESCRIPTION
Błędy w API powinny zwracać JSON a nie HTML